### PR TITLE
Bridge preview

### DIFF
--- a/src/bebb/entity.mo
+++ b/src/bebb/entity.mo
@@ -84,6 +84,7 @@ module {
   public type EntityIdErrors = {
     #Unauthorized;
     #EntityNotFound;
+    #TooManyPreviews;
     // Returns the index of the preview that is too large
     #PreviewTooLarge : Int;
     #Error;

--- a/src/bebb/entity.mo
+++ b/src/bebb/entity.mo
@@ -84,6 +84,8 @@ module {
   public type EntityIdErrors = {
     #Unauthorized;
     #EntityNotFound;
+    // Returns the index of the preview that is too large
+    #PreviewTooLarge : Int;
     #Error;
   };
 
@@ -126,6 +128,35 @@ module {
   };
 
   /**
+   * Stores the supported preview types
+   * Standard types are enumerated to create a standarized preview format.
+   * Unique formats can be stored via the other tag and labelled as such
+  */
+  public type EntityPreviewSupportedTypes = {
+      #Jpg;
+      #Png;
+      #Glb;
+      #Gltf;
+      #Other : Text;
+  };
+
+  /**
+   * Defines the type for the various previews of an entity
+  */
+  public type EntityPreview = {
+    /**
+     * Stores the type of the preview. This is used to determine how to 
+     * render the stored preview data:
+    */
+    previewType: EntityPreviewSupportedTypes;
+
+    /**
+     * The actual preview data associated with the preview
+    */
+    previewData: Blob;
+  };
+
+  /**
    * Type that defines the attributes for an Entity
   */
   public type Entity = BaseEntity.BaseEntity and {
@@ -147,6 +178,11 @@ module {
      * Contains all the bridge ids that point to this entity
     */
     toIds : EntityAttachedBridges;
+
+    /**
+     * Stores all the previews that are available for the current entity
+    */
+    previews : [EntityPreview];
   };
 
   /**
@@ -192,6 +228,7 @@ module {
       listOfEntitySpecificFieldKeys : [Text] = ["entityType", "fromIds", "toIds"];
       toIds : EntityAttachedBridges = [];
       fromIds : EntityAttachedBridges = [];
+      previews : [EntityPreview] = [];
     };
   };
 
@@ -215,6 +252,7 @@ module {
       listOfEntitySpecificFieldKeys = entity.listOfEntitySpecificFieldKeys;
       fromIds = fromIds;
       toIds = entity.toIds;
+      previews = entity.previews;
     };
   };
 
@@ -238,6 +276,7 @@ module {
       listOfEntitySpecificFieldKeys = entity.listOfEntitySpecificFieldKeys;
       fromIds = entity.fromIds;
       toIds = toIds;
+      previews = entity.previews;
     };
   };
 
@@ -247,7 +286,7 @@ module {
    *
    * @return The new entity with the values updated with the entity update values
   */
-  public func updateEntityFromUpdateObject(entityUpdateObject : EntityUpdateObject, originalEntity : Entity) : Entity {
+  public func updateEntityFromUpdateObject(entityUpdateObject : EntityUpdateObject, originalEntity : Entity) : Entity { 
     return {
       id = originalEntity.id;
       creationTimestamp = originalEntity.creationTimestamp;
@@ -256,12 +295,15 @@ module {
       settings = Option.get<EntitySettings>(entityUpdateObject.settings, originalEntity.settings);
       entityType = originalEntity.entityType;
       name = Option.get<?Text>(?entityUpdateObject.name, originalEntity.name);
+      // TODO: This isn't working properly. If you keep description null when updating, it will set it back to null and 
+      // not keep it the same value. This is true for name as well. Preview seems to work as expected
       description : ?Text = Option.get<?Text>(?entityUpdateObject.description, originalEntity.description);
       keywords : ?[Text] = Option.get<?[Text]>(?entityUpdateObject.keywords, originalEntity.keywords);
       entitySpecificFields = originalEntity.entitySpecificFields;
       listOfEntitySpecificFieldKeys = originalEntity.listOfEntitySpecificFieldKeys;
       fromIds = originalEntity.fromIds;
       toIds = originalEntity.toIds;
+      previews : [EntityPreview] = Option.get<[EntityPreview]>(entityUpdateObject.previews, originalEntity.previews);
     };
   };
 
@@ -291,6 +333,10 @@ module {
      * The Updated keywords for the entity
     */
     keywords : ?[Text];
+    /**
+     * Used to update the available previews for the entity 
+    */
+    previews : ?[EntityPreview]
   };
 
   /**

--- a/src/bebb/entity.mo
+++ b/src/bebb/entity.mo
@@ -147,7 +147,7 @@ module {
   public type EntityPreview = {
     /**
      * Stores the type of the preview. This is used to determine how to 
-     * render the stored preview data:
+     * render the stored preview data
     */
     previewType: EntityPreviewSupportedTypes;
 

--- a/src/bebb/main.mo
+++ b/src/bebb/main.mo
@@ -237,7 +237,7 @@ actor {
   * @return Either the Entity ID if the call was successful or an error if not
   */
   let oneMB : Nat = 1048576; // 1 MB
-  private let maxPreviewBlobSize : Nat = 5; 
+  private let maxPreviewBlobSize : Nat = 5 * oneMB; 
   private let maxNumPreviews = 5;
   private func updateEntity(caller : Principal, entityUpdateObject : Entity.EntityUpdateObject) : async Entity.EntityIdResult {
     var entity = getEntity(entityUpdateObject.id);

--- a/src/bebb/main.mo
+++ b/src/bebb/main.mo
@@ -237,7 +237,7 @@ actor {
   * @return Either the Entity ID if the call was successful or an error if not
   */
   let oneMB : Nat = 1048576; // 1 MB
-  private let maxPreviewBlobSize : Nat = 5 * oneMB; 
+  private let maxPreviewBlobSize : Nat = 2 * oneMB; 
   private let maxNumPreviews = 5;
   private func updateEntity(caller : Principal, entityUpdateObject : Entity.EntityUpdateObject) : async Entity.EntityIdResult {
     var entity = getEntity(entityUpdateObject.id);


### PR DESCRIPTION
# Description
1. Adds the ability to store previews associated with Entities. This allows someone with a bridge to retrieve the preview of the Entity and render it in their application

# Testing
To test you can use the candid UI
First create an Entity
<img width="1408" alt="image" src="https://github.com/Bebb-Protocol-and-Apps/BebbProtocol/assets/10234268/7ee972f6-5397-4fc3-93ac-0650aab6e38c">

Then you can update it in the update entity section. Using the ID from the created entity you can add previews to the entity in the update section
<img width="1411" alt="image" src="https://github.com/Bebb-Protocol-and-Apps/BebbProtocol/assets/10234268/aa0e8ddc-8eec-4666-9321-0182079c5430">

You can now see the previews if you retrieve the entity
<img width="1420" alt="image" src="https://github.com/Bebb-Protocol-and-Apps/BebbProtocol/assets/10234268/ef8359a8-db04-4468-8cc4-71ec1a00401f">

You can test the conditions such as adding too many previews. It may be hard to test the file size. You can manually set the file size lower in the code to like 5 Bytes and then that is easier to test that you can't upload more than the max specified size